### PR TITLE
Updated to Unity 2021b4

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 0
+  m_ShowUnitySplashScreen: 1
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
@@ -51,7 +51,7 @@ PlayerSettings:
   m_MTRendering: 1
   mipStripping: 0
   numberOfMipsStripped: 0
-  m_StackTraceTypes: 010000000100000001000000010000000100000001000000
+  m_StackTraceTypes: 010000000100000000000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
   iosUseCustomAppBackgroundBehavior: 0
@@ -320,6 +320,9 @@ PlayerSettings:
   - m_BuildTarget: WebGLSupport
     m_APIs: 0b000000
     m_Automatic: 1
+  - m_BuildTarget: LinuxStandaloneSupport
+    m_APIs: 15000000
+    m_Automatic: 0
   m_BuildTargetVRSettings:
   - m_BuildTarget: Standalone
     m_Enabled: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.1.0b1
-m_EditorVersionWithRevision: 2021.1.0b1 (9f7c487dd2da)
+m_EditorVersion: 2021.1.0b4
+m_EditorVersionWithRevision: 2021.1.0b4 (6d90c0720bd4)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Game Client/Server 
 ### Senior Design CEN4914 Spring 2021
 
-Unity Version `2021.1.0b1`
+Unity Version `2021.1.0b4`


### PR DESCRIPTION
- Updated to 2021b4
- Forced usage of Vulkan API
- Disabled Warning Stacktracing due to a bug in the Unity Collections Library (Bugged with versions 2021-on).